### PR TITLE
Allow longer file names

### DIFF
--- a/include/multinest.h
+++ b/include/multinest.h
@@ -67,9 +67,9 @@ namespace nested
 		bool initMPI, double logZero, int maxiter, void (*LogLike)(double *Cube, int &n_dim, int &n_par, double &lnew, void *),
 		void (*dumper)(int &, int &, int &, double **, double **, double **, double &, double &, double &, double &, void *), void *context)
 	{
-		char t_root[100];
-		std::fill(t_root, t_root + 100, ' ');
-		snprintf(t_root, 99, "%s", root.c_str());
+		char t_root[1000];
+		std::fill(t_root, t_root + 1000, ' ');
+		snprintf(t_root, 999, "%s", root.c_str());
 		int root_len = strlen(t_root);
 		t_root[strlen(t_root)] = ' ';
 	
@@ -104,7 +104,7 @@ void (*dumper)(int *, int *, int *, double **, double **, double **, double *, d
 void *context)
 {
 	int i;
-	for (i = strlen(root); i < 100; i++) root[i] = ' ';
+	for (i = strlen(root); i < 1000; i++) root[i] = ' ';
 
         NESTRUN(&IS, &mmodal, &ceff, &nlive, &tol, &efr, &ndims, &nPar, &nClsPar, &maxModes, &updInt, &Ztol,
         root, &seed, pWrap, &fb, &resume, &outfile, &initMPI, &logZero, &maxiter, LogLike, dumper, context);

--- a/src/cwrapper.f90
+++ b/src/cwrapper.f90
@@ -114,11 +114,11 @@ module cnested
    	type(c_funptr),  intent(in), value :: loglike, dumper
 	type(c_ptr),     intent(in) :: context
 
-	character(len=100) :: fnest_root
+	character(len=1000) :: fnest_root
 	integer :: i, context_f
 
 	fnest_root = ' '
-	do i = 1, 100
+	do i = 1, 1000
 		if (nest_root(i) == C_NULL_CHAR) then
 			exit
 		else

--- a/src/example_ackley/params.f90
+++ b/src/example_ackley/params.f90
@@ -52,7 +52,7 @@ implicit none
       	parameter(nest_efr=0.5d0)
       
       	!root for saving posterior files
-      	character*100 nest_root
+      	character*1000 nest_root
 	parameter(nest_root='chains/ackley-')
 	
 	!after how many iterations feedback is required & the output files should be updated

--- a/src/example_eggbox_C++/eggbox.cc
+++ b/src/example_eggbox_C++/eggbox.cc
@@ -134,7 +134,7 @@ int main(int argc, char *argv[])
 	int pWrap[ndims];				// which parameters to have periodic boundary conditions?
 	for(int i = 0; i < ndims; i++) pWrap[i] = 0;
 	
-	char root[100] = "chains/eggboxCC-";			// root for output files
+	char root[1000] = "chains/eggboxCC-";			// root for output files
 	
 	int seed = -1;					// random no. generator seed, if < 0 then take the seed from system clock
 	

--- a/src/example_eggbox_C/eggbox.c
+++ b/src/example_eggbox_C/eggbox.c
@@ -135,7 +135,7 @@ int main(int argc, char *argv[])
 	int pWrap[ndims];				// which parameters to have periodic boundary conditions?
 	for(i = 0; i < ndims; i++) pWrap[i] = 0;
 	
-	char root[100] = "chains/eggboxC-";		// root for output files
+	char root[1000] = "chains/eggboxC-";		// root for output files
 	
 	int seed = -1;					// random no. generator seed, if < 0 then take the seed from system clock
 	

--- a/src/example_gauss_shell/params.f90
+++ b/src/example_gauss_shell/params.f90
@@ -70,7 +70,7 @@ implicit none
       	parameter(nest_efr=0.05d0)
       
       	!root for saving posterior files
-      	character*100 nest_root
+      	character*1000 nest_root
 	parameter(nest_root='chains/1-')
 	
 	!after how many iterations feedback is required & the output files should be updated

--- a/src/example_gaussian/params.f90
+++ b/src/example_gaussian/params.f90
@@ -55,7 +55,7 @@ implicit none
       	parameter(nest_efr=0.1d0)
       
       	!root for saving posterior files
-      	character*100 nest_root
+      	character*1000 nest_root
 	parameter(nest_root='chains/gaussian-')
 	
 	!after how many iterations feedback is required & the output files should be updated

--- a/src/example_himmelblau/params.f90
+++ b/src/example_himmelblau/params.f90
@@ -52,7 +52,7 @@ implicit none
       	parameter(nest_efr=0.5d0)
       
       	!root for saving posterior files
-      	character*100 nest_root
+      	character*1000 nest_root
 	parameter(nest_root='chains/himmelblau-')
 	
 	!after how many iterations feedback is required & the output files should be updated

--- a/src/example_obj_detect/params.f90
+++ b/src/example_obj_detect/params.f90
@@ -68,7 +68,7 @@ implicit none
       	parameter(nest_efr=0.8d0)
       
       	!root for saving posterior files
-      	character*100 nest_root
+      	character*1000 nest_root
 	parameter(nest_root='chains/2-')
 	
 	!after how many iterations feedback is required & the output files should be updated

--- a/src/example_rosenbrock/params.f90
+++ b/src/example_rosenbrock/params.f90
@@ -52,7 +52,7 @@ implicit none
       	parameter(nest_efr=0.3d0)
       
       	!root for saving posterior files
-      	character*100 nest_root
+      	character*1000 nest_root
 	parameter(nest_root='chains/rosenbrock-')
 	
 	!after how many iterations feedback is required & the output files should be updated

--- a/src/nested.F90
+++ b/src/nested.F90
@@ -56,7 +56,7 @@ contains
 	integer nest_ndims,nest_nlive,nest_updInt,context,seed,i
 	integer maxClst,nest_nsc,nest_totPar,nest_nCdims,nest_pWrap(*),nest_maxIter
 	logical nest_IS,nest_mmodal,nest_fb,nest_resume,nest_ceff,nest_outfile,initMPI
-	character(LEN=100) nest_root
+	character(LEN=1000) nest_root
 	double precision nest_tol,nest_ef,nest_Ztol,nest_logZero
 	
 	INTERFACE
@@ -255,7 +255,7 @@ contains
 	double precision, allocatable :: l(:) !log-likelihood
 	double precision vnow1!current vol
 	double precision ltmp(totPar+2)
-	character(len=100) fmt
+	character(len=1000) fmt
 	integer np,i,j,k,ios
 	logical flag
 
@@ -388,7 +388,7 @@ contains
     	double precision, allocatable :: pnewP(:,:), phyPnewP(:,:), lnewP(:)
     	double precision p(ndims,nlive+1), phyP(totPar,nlive+1), l(nlive+1)
     	integer id
-    	character(len=100) fmt,fmt2
+    	character(len=1000) fmt,fmt2
 #ifdef MPI
 	double precision, allocatable ::  tmpl(:), tmpp(:,:), tmpphyP(:,:)
 	integer q
@@ -662,8 +662,8 @@ contains
 	logical eswitch,peswitch,cSwitch !whether to do ellipsoidal sampling or not
 	logical remFlag, acpt, flag, flag2
 	integer funit1, funit2 !file units
-	character(len=100) fName1, fName2 !file names
-	character(len=100) fmt,fmt1
+	character(len=1000) fName1, fName2 !file names
+	character(len=1000) fmt,fmt1
 	
 	!diagnostics for determining when to do eigen analysis
 	integer neVol

--- a/src/nested.F90
+++ b/src/nested.F90
@@ -33,7 +33,7 @@ module Nested
   integer maxIter
   logical fback,resumeFlag,dlive,genLive,dino
   !output files name
-  character(LEN=100)physname,broot,rname,resumename,livename,evname,IS_Files(3)
+  character(LEN=1000)physname,broot,rname,resumename,livename,evname,IS_Files(3)
   !output file units
   integer u_ev,u_resume,u_phys,u_live,u_IS(3)
   double precision gZ,ginfo !total log(evidence) & info

--- a/src/posterior.F90
+++ b/src/posterior.F90
@@ -25,7 +25,7 @@ contains
   	
 	double precision Ztol !null evidence
 	integer nIter !globff (total no. replacements)
-	character(LEN=100)root !base root
+	character(LEN=1000)root !base root
 	integer nLpt !no. of live points
 	integer ndim !dimensionality
 	integer nCdim !no. of parameters to cluster on
@@ -38,8 +38,8 @@ contains
 	logical IS !importance sampling?
 	double precision IS_Z(2) !importance sampling log(Z) estimate & its standard deviation
 	logical ic_reme(ic_n)
-  	character(len=100) evfile,livefile,postfile,resumefile
-      	character(len=100) sepFile,statsFile,postfile4,strictSepFile,summaryFile
+  	character(len=1000) evfile,livefile,postfile,resumefile
+      	character(len=1000) sepFile,statsFile,postfile4,strictSepFile,summaryFile
   	character(len=32) fmt,fmt2
       	logical l1
       	double precision d1,d2,urv


### PR DESCRIPTION
In v3.12 of MultiNest is allows file names up to 1000 characters long. It would be good to have this feature in this version too. This would help the use of PyMultinest as implemented through bilby, which uses the conda install of MultiNest based off this repo.