### PR TITLE
example_eggbox_C: fix call to FIND_LIBRARY()

### DIFF
--- a/src/example_eggbox_C/CMakeLists.txt
+++ b/src/example_eggbox_C/CMakeLists.txt
@@ -4,11 +4,11 @@ cmake_minimum_required(VERSION 2.8.12)
 # FIND_LIBRARY(MultiNest)
 # INCLUDE_DIRECTORIES(${MultiNest_INCLUDE_PATH})
 
-FIND_LIBRARY(m REQUIRED)
+FIND_LIBRARY(LIBM m REQUIRED)
 
 FILE(GLOB SOURCE *.c)
 add_executable(eggboxC ${SOURCE})
-target_link_libraries(eggboxC ${MultiNest_LIBRARIES} m)
+target_link_libraries(eggboxC ${MultiNest_LIBRARIES} ${LIBM})
 
 # Set install directory
 INSTALL(TARGETS eggboxC DESTINATION bin)


### PR DESCRIPTION
The call to FIND_LIBRARY() is not correct, it should first take the name of a variable where to store the location of the found library location before the name of the library. This resolves a potential failure of the cmake call which leads to the following error:

  CMake Error at src/example_eggbox_C/CMakeLists.txt:7 (FIND_LIBRARY):
    Could not find m using the following names:

Additionaly this commit adjusts the call to target_link_libraries() accordingly to use the result of FIND_LIBRARY().